### PR TITLE
Add WhatsApp

### DIFF
--- a/src/Chencha/Share/Share.php
+++ b/src/Chencha/Share/Share.php
@@ -100,4 +100,8 @@ class Share {
 	public function vk(){
 		return 'http://vk.com/share.php?url='.$this->link.(($this->media) ? '&image='.$this->media : '').(($this->text) ? '&title='.$this->text : '').'&noparse=false';
 	}
+	
+	public function whatsapp(){
+		return 'whatsapp://send?text='.(($this->text) ? $this->text.'%20' : '').$this->link;
+	}
 }


### PR DESCRIPTION
WhatsApp sharing support, using whatsapp:// protocol with basic text parameter. On mobile, this opens the recipient selection in WhatsApp. On desktop, the behaviour is undefined. Don't show it where it's not usable. The text is formatted simply as "{text} {link}".
