### PR TITLE
Allow services to accept array

### DIFF
--- a/src/Chencha/Share/Share.php
+++ b/src/Chencha/Share/Share.php
@@ -22,6 +22,10 @@ class Share {
 
 	public function services(){
 		$services = func_get_args();
+		
+		if (is_array($services[0])) {
+            $services = $services[0];
+        }
 
         if (empty($services)) {
             $services = array_keys($this->app->config->get('social-share.services'));


### PR DESCRIPTION
Allows the service() function to accept an array as it's first parameter. This way, a group of links can be built dynamically from an array of configured providers.
