### PR TITLE
add exceptions to provide better error message

### DIFF
--- a/src/Chencha/Share/Exceptions/NoServiceIsAvailable.php
+++ b/src/Chencha/Share/Exceptions/NoServiceIsAvailable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Chencha\Share\Exceptions;
+
+class NoServiceIsAvailable extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct("No service is found in config file");
+    }
+}

--- a/src/Chencha/Share/Exceptions/ServiceNotSupportedException.php
+++ b/src/Chencha/Share/Exceptions/ServiceNotSupportedException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Chencha\Share\Exceptions;
+
+class ServiceNotSupportedException extends \Exception
+{
+    public function __construct($serviceId, array $supportedServices)
+    {
+        $message = "`{$serviceId}` is not supported, supported services are: " . implode(', ', $supportedServices);
+
+        parent::__construct($message);
+    }
+}


### PR DESCRIPTION
When you accidentally call a method by mistake, for example in capital letters, you will receive a message (Undefined index: uri) that you do not understand the problem. This error occurs when the service is not supported. A better error is added to this pull request. 

@example
`LinkedIn` is not supported, supported services are: delicious, digg, email, evernote, ...