### PR TITLE
Share URL changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ This is a fork of John's share for Laravel 4.
  
 ## Services available
 
-- Delicious : delicious
 - Digg : digg
 - Email : email
 - Evernote : evernote
 - Facebook : facebook
 - Gmail : gmail
-- Google Plus : gplus
 - LinkedIn : linkedin
 - Pinterest : pinterest
 - Reddit : reddit
@@ -20,7 +18,6 @@ This is a fork of John's share for Laravel 4.
 - Telegram.me : telegramMe
 - Tumblr : tumblr
 - Twitter : twitter
-- Viadeo : viadeo
 - vk.com : vk
 
 
@@ -48,13 +45,12 @@ Get many links
 
 	Route::get('/', function()
 	{
-		return Share::load('http://www.example.com', 'Link description')->services('facebook', 'gplus', 'twitter');
+		return Share::load('http://www.example.com', 'Link description')->services('facebook', 'twitter');
 	});
 
 Returns an array :
 
     {
-        "gplus" : "https://plus.google.com/share?url=http%3A%2F%2Fwww.example.com",
         "twitter" : "https://twitter.com/intent/tweet?url=http%3A%2F%2Fwww.example.com&text=Link+description",
         "facebook" : "https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.example.com&title=Link+description"
     }
@@ -102,3 +98,11 @@ Localizing? Easy, use Laravel's trans() call:
 Create a file at resources/lang/en/share.php with your choice of subject and body. URLs arguably have a maximum length of 2000 characters.
 
 Notice the use of *<?php echo $sep; ?>*. It's the only way to print out an unencoded ampersand (if configured that way).
+
+## Upgrades
+
+When the package is upgraded, changes to the config and views should be republished into your project:
+
+    php artisan vendor:publish --provider='Chencha\Share\ShareServiceProvider'
+
+Use source control to work out what has changed if you have customized the files.

--- a/config/social-share.php
+++ b/config/social-share.php
@@ -3,29 +3,24 @@
 return [
     'separator' => '&',
     'services' => [
-        'delicious' => [ 'uri' => 'https://delicious.com/post' ],
-        'digg' => [ 'uri' => 'http://www.digg.com/submit' ],
+        'digg' => [ 'uri' => 'https://digg.com/news/submit-link', 'only' => [ 'url' ] ],
         'email' => [ 'view' => 'social-share::email' ],
         'evernote' => [ 'uri' => 'http://www.evernote.com/clip.action' ],
-        'facebook' => [ 'uri' => 'https://www.facebook.com/sharer/sharer.php', 'urlName' => 'u',  ],
-        'gmail' => [ 'uri' => 'https://mail.google.com/mail/', 'urlName' => 'su', 'titleName' => 'body', 'extra' => [
+        'facebook' => [ 'uri' => 'https://www.facebook.com/sharer/sharer.php', 'urlName' => 'u', 'titleName' => 'quote'],
+        'gmail' => [ 'uri' => 'https://mail.google.com/mail/', 'urlName' => 'body', 'titleName' => 'su', 'extra' => [
             'view' => 'cm',
             'fs' => 1,
             'to' => '',
             'ui' => 2,
             'tf' => 1,
         ]],
-        'gplus' => [ 'uri' => 'https://plus.google.com/share', 'only' => [ 'url' ] ],
-        'linkedin' => [ 'uri' => 'http://www.linkedin.com/shareArticle', 'extra' => [ 'mini' => 'true' ] ],
-        'pinterest' => [ 'uri' => 'http://pinterest.com/pin/create/button/', 'titleName' => 'description', 'mediaName' => 'media' ],
-        'reddit' => [ 'uri' => 'http://www.reddit.com/submit' ],
-        'scoopit' => [ 'uri' => 'http://www.scoop.it/oexchange/share' ],
+        'linkedin' => [ 'uri' => 'https://www.linkedin.com/sharing/share-offsite/', 'only' => [ 'url' ] ],
+        'pinterest' => [ 'uri' => 'https://pinterest.com/pin/create/button/', 'only' => [ 'url' ] ],
+        'reddit' => [ 'uri' => 'https://www.reddit.com/submit' ],
+        'scoopit' => [ 'uri' => 'https://www.scoop.it/bookmarklet', 'only' => [ 'url' ] ],
         'telegramMe' => [ 'uri' => 'https://telegram.me/share/url', 'titleName' => 'text' ],
-        'tumblr' => [ 'uri' => 'http://www.tumblr.com/share', 'urlName' => 'u', 'titleName' => 't', 'extra' => [
-            'v' => 3,
-        ]],
+        'tumblr' => [ 'uri' => 'https://www.tumblr.com/widgets/share/tool', 'urlName' => 'canonicalUrl' ],
         'twitter' => [ 'uri' => 'https://twitter.com/intent/tweet', 'titleName' => 'text' ],
-        'viadeo' => [ 'uri' => 'http://www.viadeo.com/' ],
         'vk' => [ 'uri' => 'http://vk.com/share.php', 'mediaName' => 'image', 'extra' => [
             'noparse' => 'false',
         ]],

--- a/config/social-share.php
+++ b/config/social-share.php
@@ -3,6 +3,7 @@
 return [
     'separator' => '&',
     'services' => [
+        'blogger' => [ 'uri' => 'https://www.blogger.com/blog-this.g', 'urlName' => 'u', 'titleName' => 'n' ],
         'digg' => [ 'uri' => 'https://digg.com/news/submit-link', 'only' => [ 'url' ] ],
         'email' => [ 'view' => 'social-share::email' ],
         'evernote' => [ 'uri' => 'http://www.evernote.com/clip.action' ],

--- a/config/social-share.php
+++ b/config/social-share.php
@@ -7,7 +7,7 @@ return [
         'email' => [ 'view' => 'social-share::email' ],
         'evernote' => [ 'uri' => 'http://www.evernote.com/clip.action' ],
         'facebook' => [ 'uri' => 'https://www.facebook.com/sharer/sharer.php', 'urlName' => 'u', 'titleName' => 'quote'],
-        'gmail' => [ 'uri' => 'https://mail.google.com/mail/', 'urlName' => 'body', 'titleName' => 'su', 'extra' => [
+        'gmail' => [ 'uri' => 'https://mail.google.com/mail/', 'urlName' => 'su', 'titleName' => 'body', 'extra' => [
             'view' => 'cm',
             'fs' => 1,
             'to' => '',

--- a/tests/ShareTest.php
+++ b/tests/ShareTest.php
@@ -10,27 +10,22 @@ use Illuminate\View\Factory as ViewFactory;
 class ShareTest extends TestCase
 {
     protected $expected = [
-        "delicious" => "https://delicious.com/post?url=http%3A%2F%2Fwww.example.com&title=Example",
-        "digg" => "http://www.digg.com/submit?url=http%3A%2F%2Fwww.example.com&title=Example",
-        "email" => "mailto:?subject=Example&body=http%3A%2F%2Fwww.example.com",
-        "evernote" => "http://www.evernote.com/clip.action?url=http%3A%2F%2Fwww.example.com&title=Example",
-        "facebook" => "https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.example.com&title=Example",
-        "gmail" => "https://mail.google.com/mail/?su=http%3A%2F%2Fwww.example.com&body=Example&view=cm&fs=1&to=&ui=2&tf=1",
-        "gplus" => "https://plus.google.com/share?url=http%3A%2F%2Fwww.example.com",
-        "linkedin" => "http://www.linkedin.com/shareArticle?url=http%3A%2F%2Fwww.example.com&title=Example&mini=true",
-        "pinterest" => "http://pinterest.com/pin/create/button/?url=http%3A%2F%2Fwww.example.com&description=Example&media=Media",
-        "reddit" => "http://www.reddit.com/submit?url=http%3A%2F%2Fwww.example.com&title=Example",
-        "scoopit" => "http://www.scoop.it/oexchange/share?url=http%3A%2F%2Fwww.example.com&title=Example",
-        "telegramMe" => "https://telegram.me/share/url?url=http%3A%2F%2Fwww.example.com&text=Example",
-        "tumblr" => "http://www.tumblr.com/share?u=http%3A%2F%2Fwww.example.com&t=Example&v=3",
-        "twitter" => "https://twitter.com/intent/tweet?url=http%3A%2F%2Fwww.example.com&text=Example",
-        "viadeo" => "http://www.viadeo.com/?url=http%3A%2F%2Fwww.example.com&title=Example",
-        "vk" => "http://vk.com/share.php?url=http%3A%2F%2Fwww.example.com&title=Example&image=Media&noparse=false",
-        "whatsapp" => "whatsapp://send?text=Example%20http%3A%2F%2Fwww.example.com",
-        "whatsapp" => "whatsapp://send?text=Example%20http%3A%2F%2Fwww.example.com",
-
-        "service" => "http://service.example.com?url=http%3A%2F%2Fwww.example.com&title=Example&media=Media",
-        "service2" => "http://service2.example.com?url=http%3A%2F%2Fwww.example.com&title=Example&extra1=Extra%201&extra2=Extra%202",
+        'digg' => 'https://digg.com/news/submit-link?url=http%3A%2F%2Fwww.example.com',
+        'email' => 'mailto:?subject=Example&body=http%3A%2F%2Fwww.example.com',
+        'evernote' => 'http://www.evernote.com/clip.action?url=http%3A%2F%2Fwww.example.com&title=Example',
+        'facebook' => 'https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.example.com&quote=Example',
+        'gmail' => 'https://mail.google.com/mail/?su=http%3A%2F%2Fwww.example.com&body=Example&view=cm&fs=1&to=&ui=2&tf=1',
+        'linkedin' => 'https://www.linkedin.com/sharing/share-offsite/?url=http%3A%2F%2Fwww.example.com',
+        'pinterest' => 'https://pinterest.com/pin/create/button/?url=http%3A%2F%2Fwww.example.com',
+        'reddit' => 'https://www.reddit.com/submit?url=http%3A%2F%2Fwww.example.com&title=Example',
+        'scoopit' => 'https://www.scoop.it/bookmarklet?url=http%3A%2F%2Fwww.example.com',
+        'telegramMe' => 'https://telegram.me/share/url?url=http%3A%2F%2Fwww.example.com&text=Example',
+        'tumblr' => 'https://www.tumblr.com/widgets/share/tool?canonicalUrl=http%3A%2F%2Fwww.example.com&title=Example',
+        'twitter' => 'https://twitter.com/intent/tweet?url=http%3A%2F%2Fwww.example.com&text=Example',
+        'vk' => 'http://vk.com/share.php?url=http%3A%2F%2Fwww.example.com&title=Example&image=Media&noparse=false',
+        'whatsapp' => 'whatsapp://send?text=Example%20http%3A%2F%2Fwww.example.com',
+        'service' => 'http://service.example.com?url=http%3A%2F%2Fwww.example.com&title=Example&media=Media',
+        'service2' => 'http://service2.example.com?url=http%3A%2F%2Fwww.example.com&title=Example&extra1=Extra%201&extra2=Extra%202',
     ];
 
     protected function getPackageProviders($app)
@@ -141,13 +136,11 @@ class ShareTest extends TestCase
     public function testServices()
     {
         $actual = Share::load('http://www.example.com', 'Example', 'Media')->services(
-            'delicious',
             'digg',
             'email',
             'evernote',
             'facebook',
             'gmail',
-            'gplus',
             'linkedin',
             'pinterest',
             'reddit',
@@ -155,7 +148,6 @@ class ShareTest extends TestCase
             'telegramMe',
             'tumblr',
             'twitter',
-            'viadeo',
             'vk',
             'whatsapp',
             'service',
@@ -169,13 +161,11 @@ class ShareTest extends TestCase
     {
         $actual = Share::load('http://www.example.com', 'Example', 'Media')->services(
             [
-                'delicious',
                 'digg',
                 'email',
                 'evernote',
                 'facebook',
                 'gmail',
-                'gplus',
                 'linkedin',
                 'pinterest',
                 'reddit',
@@ -183,10 +173,8 @@ class ShareTest extends TestCase
                 'telegramMe',
                 'tumblr',
                 'twitter',
-                'viadeo',
                 'vk',
                 'whatsapp',
-
                 'service',
                 'service2',
             ]
@@ -214,20 +202,10 @@ class ShareTest extends TestCase
     /**
      * @group live
      */
-    public function testDelicious()
-    {
-        $url = 'https://delicious.com/post?url=http%3A%2F%2Fwww.example.com&title=Example';
-        $this->assertEquals($url, Share::load('http://www.example.com', 'Example')->delicious());
-        // $this->assertPageFound($url);
-    }
-
-    /**
-     * @group live
-     */
     public function testDigg()
     {
-        $url = 'http://www.digg.com/submit?url=http%3A%2F%2Fwww.example.com&title=Example';
-        $this->assertEquals($url, Share::load('http://www.example.com', 'Example')->digg());
+        $url = 'https://digg.com/news/submit-link?url=http%3A%2F%2Fwww.example.com';
+        $this->assertEquals($url, Share::load('http://www.example.com')->digg());
         // $this->assertPageFound($url);
     }
 
@@ -256,7 +234,7 @@ class ShareTest extends TestCase
      */
     public function testFacebook()
     {
-        $url = 'https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.example.com&title=Example';
+        $url = 'https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.example.com&quote=Example';
         $this->assertEquals($url, Share::load('http://www.example.com', 'Example')->facebook());
         // $this->assertPageFound($url);
     }
@@ -274,20 +252,10 @@ class ShareTest extends TestCase
     /**
      * @group live
      */
-    public function testGplus()
-    {
-        $url = 'https://plus.google.com/share?url=http%3A%2F%2Fwww.example.com';
-        $this->assertEquals($url, Share::load('http://www.example.com')->gplus());
-        // $this->assertPageFound($url);
-    }
-
-    /**
-     * @group live
-     */
     public function testLinkedin()
     {
-        $url = 'http://www.linkedin.com/shareArticle?url=http%3A%2F%2Fwww.example.com&title=Example&mini=true';
-        $this->assertEquals($url, Share::load('http://www.example.com', 'Example')->linkedin());
+        $url = 'https://www.linkedin.com/sharing/share-offsite/?url=http%3A%2F%2Fwww.example.com';
+        $this->assertEquals($url, Share::load('http://www.example.com')->linkedin());
         // $this->assertPageFound($url);
     }
 
@@ -296,8 +264,8 @@ class ShareTest extends TestCase
      */
     public function testPinterest()
     {
-        $url = 'http://pinterest.com/pin/create/button/?url=http%3A%2F%2Fwww.example.com&description=Example&media=Media';
-        $this->assertEquals($url, Share::load('http://www.example.com', 'Example', 'Media')->pinterest());
+        $url = 'https://pinterest.com/pin/create/button/?url=http%3A%2F%2Fwww.example.com';
+        $this->assertEquals($url, Share::load('http://www.example.com')->pinterest());
         // $this->assertPageFound($url);
     }
 
@@ -306,7 +274,7 @@ class ShareTest extends TestCase
      */
     public function testReddit()
     {
-        $url = 'http://www.reddit.com/submit?url=http%3A%2F%2Fwww.example.com&title=Example';
+        $url = 'https://www.reddit.com/submit?url=http%3A%2F%2Fwww.example.com&title=Example';
         $this->assertEquals($url, Share::load('http://www.example.com', 'Example')->reddit());
         // $this->assertPageFound($url);
     }
@@ -316,8 +284,8 @@ class ShareTest extends TestCase
      */
     public function testScoopit()
     {
-        $url = 'http://www.scoop.it/oexchange/share?url=http%3A%2F%2Fwww.example.com&title=Example';
-        $this->assertEquals($url, Share::load('http://www.example.com', 'Example')->scoopit());
+        $url = 'https://www.scoop.it/bookmarklet?url=http%3A%2F%2Fwww.example.com';
+        $this->assertEquals($url, Share::load('http://www.example.com')->scoopit());
         // $this->assertPageFound($url);
     }
 
@@ -336,7 +304,7 @@ class ShareTest extends TestCase
      */
     public function testTumblr()
     {
-        $url = 'http://www.tumblr.com/share?u=http%3A%2F%2Fwww.example.com&t=Example&v=3';
+        $url = 'https://www.tumblr.com/widgets/share/tool?canonicalUrl=http%3A%2F%2Fwww.example.com&title=Example';
         $this->assertEquals($url, Share::load('http://www.example.com', 'Example')->tumblr());
         // $this->assertPageFound($url);
     }
@@ -348,16 +316,6 @@ class ShareTest extends TestCase
     {
         $url = 'https://twitter.com/intent/tweet?url=http%3A%2F%2Fwww.example.com&text=Example';
         $this->assertEquals($url, Share::load('http://www.example.com', 'Example')->twitter());
-        // $this->assertPageFound($url);
-    }
-
-    /**
-     * @group live
-     */
-    public function testViadeo()
-    {
-        $url = 'http://www.viadeo.com/?url=http%3A%2F%2Fwww.example.com&title=Example';
-        $this->assertEquals($url, Share::load('http://www.example.com', 'Example')->viadeo());
         // $this->assertPageFound($url);
     }
 

--- a/tests/ShareTest.php
+++ b/tests/ShareTest.php
@@ -10,6 +10,7 @@ use Illuminate\View\Factory as ViewFactory;
 class ShareTest extends TestCase
 {
     protected $expected = [
+        'blogger' => 'https://www.blogger.com/blog-this.g?u=http%3A%2F%2Fwww.example.com&n=Example',
         'digg' => 'https://digg.com/news/submit-link?url=http%3A%2F%2Fwww.example.com',
         'email' => 'mailto:?subject=Example&body=http%3A%2F%2Fwww.example.com',
         'evernote' => 'http://www.evernote.com/clip.action?url=http%3A%2F%2Fwww.example.com&title=Example',
@@ -136,6 +137,7 @@ class ShareTest extends TestCase
     public function testServices()
     {
         $actual = Share::load('http://www.example.com', 'Example', 'Media')->services(
+            'blogger',
             'digg',
             'email',
             'evernote',
@@ -161,6 +163,7 @@ class ShareTest extends TestCase
     {
         $actual = Share::load('http://www.example.com', 'Example', 'Media')->services(
             [
+                'blogger',
                 'digg',
                 'email',
                 'evernote',
@@ -197,6 +200,16 @@ class ShareTest extends TestCase
 
         $response = $client->head($url);
         $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @group live
+     */
+    public function testBlogger()
+    {
+        $url = 'https://www.blogger.com/blog-this.g?u=http%3A%2F%2Fwww.example.com&n=Example';
+        $this->assertEquals($url, Share::load('http://www.example.com', 'Example')->blogger());
+        // $this->assertPageFound($url);
     }
 
     /**


### PR DESCRIPTION
- make it possible to share title on facebook (linkedin does not allow this).
- Update share URLs, remove dead services, add some requested ones (sorry so late :blush:).

Resolves #45 
Resolves #55
Resolves #33 